### PR TITLE
Add support for shared token for authentication

### DIFF
--- a/gds_metrics/__init__.py
+++ b/gds_metrics/__init__.py
@@ -29,7 +29,10 @@ class GDSMetrics(object):
     def __init__(self):
         self.metrics_path = os.environ.get('PROMETHEUS_METRICS_PATH', '/metrics')
         if os.environ.get("METRICS_BASIC_AUTH", "true") == "true":
-            self.auth_token = json.loads(os.environ.get("VCAP_APPLICATION", "{}")).get("application_id")
+            if os.environ.get("METRICS_BASIC_AUTH_TOKEN"):
+                self.auth_token = os.environ["METRICS_BASIC_AUTH_TOKEN"]
+            else:
+                self.auth_token = json.loads(os.environ.get("VCAP_APPLICATION", "{}")).get("application_id")
         else:
             self.auth_token = False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from gds_metrics import GDSMetrics
 
 
 FAKE_APP_ID = "123"
+FAKE_BASIC_AUTH_TOKEN = "abcd"
 SLOW_REQUEST_DURATION = 0.1
 
 
@@ -70,6 +71,24 @@ def client_without_basic_auth(app, mocker):
 def client_without_env_app_id(app, mocker):
     with app.test_request_context(), app.test_client() as client:
         mocker.patch.dict(os.environ, {'VCAP_APPLICATION': '{}'})
+
+        metrics = GDSMetrics()
+        metrics.init_app(app)
+
+        yield client
+
+
+@pytest.fixture(scope='function')
+def client_with_auth_token(app, mocker):
+    with app.test_request_context(), app.test_client() as client:
+        mocker.patch.dict(
+            os.environ,
+            {
+                'VCAP_APPLICATION': '{"application_id": "' + FAKE_APP_ID + '"}',
+                'METRICS_BASIC_AUTH': 'true',
+                'METRICS_BASIC_AUTH_TOKEN': FAKE_BASIC_AUTH_TOKEN,
+            }
+        )
 
         metrics = GDSMetrics()
         metrics.init_app(app)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,8 @@
 import pytest
-from tests.conftest import FAKE_APP_ID, SLOW_REQUEST_DURATION
+from tests.conftest import FAKE_APP_ID, FAKE_BASIC_AUTH_TOKEN, SLOW_REQUEST_DURATION
 
 VALID_AUTH_HEADER = 'Authorization', 'Bearer {}'.format(FAKE_APP_ID)
+VALID_AUTH_HEADER_TOKEN = 'Authorization', 'Bearer {}'.format(FAKE_BASIC_AUTH_TOKEN)
 
 
 @pytest.mark.parametrize('auth_header,expected_status', [
@@ -14,6 +15,17 @@ def test_auth_header_returns_expected_response(client, auth_header, expected_sta
         '/metrics',
         headers=auth_header
     )
+    assert response.status_code == expected_status
+
+
+@pytest.mark.parametrize('auth_header,expected_status', [
+    (None, 401),
+    ([VALID_AUTH_HEADER_TOKEN], 200),
+    ([VALID_AUTH_HEADER], 403),
+    ([('Authorization', 'Bearer invalid-token')], 403),
+])
+def test_auth_token_takes_precedence_over_application_id(client_with_auth_token, auth_header, expected_status):
+    response = client_with_auth_token.get('/metrics', headers=auth_header)
     assert response.status_code == expected_status
 
 


### PR DESCRIPTION
This is a backwards compatible change which will allow for a pre-shared
token to be distributed with our apps and get prometheus to use this
token to authenticate itself.

This results in a much simpler deployment model where prometheus
scraping requests don't need to be proxied through another server and
can allow for hosting prometheus on PaaS.